### PR TITLE
Fix custom model script path and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ uv pip install -r requirements.txt
    OPENAI_API_KEY=<key for the demo chatbot>
    GROQ_API_KEY=<Groq API key>
    GOOGLE_API_KEY=<Gemini API key>
+   OPENAI_BASE_URL=<custom base URL for OpenAI API (optional)>
    ```
 2. Run any script in `translations/` to translate the dataset. Most scripts now
    accept `OUTPUT_DIR` and `OPENAI_MODEL_NAME` from the environment. For example:
    ```bash
-   OPENAI_MODEL_NAME=gpt-4o OUTPUT_DIR=gpt-4o python translations/llama3.3_parallel.py
+   OPENAI_MODEL_NAME=gpt-4o OUTPUT_DIR=gpt-4o \
+   MAX_PARALLEL=4 python translations/custom-model-parallel.py
    ```
    Each script writes JSON files to a folder named after the model (or the value
    of `OUTPUT_DIR`).

--- a/translations/custom-model-parallel.py
+++ b/translations/custom-model-parallel.py
@@ -3,6 +3,7 @@ import json
 import os
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from constants import prompt
 from dotenv import load_dotenv
 
@@ -62,7 +63,8 @@ def process_row(idx: int, hawaiian_text: str, reference_translation: str):
 
 
 def main():
-    file_path = "../data/dataset.csv"
+    base_dir = Path(__file__).resolve().parents[1]
+    file_path = base_dir / "data" / "dataset.csv"
     try:
         df = pd.read_csv(file_path)
         print(f"Successfully loaded {file_path}. Found {len(df)} rows.")


### PR DESCRIPTION
## Summary
- fix dataset path in `custom-model-parallel.py`
- mention `OPENAI_BASE_URL` and parallel example in README

## Testing
- `python -m py_compile translations/custom-model-parallel.py`

------
https://chatgpt.com/codex/tasks/task_e_68521995c6c883259e71d1c7b8ff1bdb